### PR TITLE
Documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ MyApp.User = Ember.Object.extend(Ember.Validations, {
       custom: {
         validator: function(object, attribute, value) {
           if (!value.match(/[A-Z]/)) {
-            this.get('validationErrors').add(attribute, "does not contain capital letters");
+            object.get('validationErrors').add(attribute, null, null, "does not contain capital letters");
           }
         }
       }


### PR DESCRIPTION
It seems the example in the README of using an in-line custom validator function within the validations object doesn't work with the current interfaces.
1. The example currently uses `this.get('validationErrors')` but `this` refers to the `Ember.Validator` instance, not the object being validated, therefore the passed in reference to the object being validated should used.
2. The `Ember.ValidationErrors.add` function takes 4 arguments:
   `add: function(attributePath, key, format, customMessage) {...`
   So I suppose if we want to just pass in a custom message (one that doesn't have a registered key in the `Ember.ValidationError.messages` object) then we must pass null or for the `key` and (optionally) the `format` arguments. 

Unless I'm missing something.
