### PR TITLE
allowBlank option on numericality validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ myUser.get('validationErrors.allMessages');
 
 There are also `keys`, `allKeys` properties that works like messages.
 
+## Skipping Validations
+
+The built in `format`, `length` and `numericality` validators have an
+`allowBlank` option which will cause validations to be skipped on blank
+data (a blank string) when set to true.
+
 # Building Ember-Validations
 
 1. Run `rake dist` task to build Ember-validations.js. Two builds will be placed in the `dist/` directory.

--- a/README.md
+++ b/README.md
@@ -125,9 +125,10 @@ There are also `keys`, `allKeys` properties that works like messages.
 
 ## Skipping Validations
 
-The built in `format`, `length` and `numericality` validators have an
-`allowBlank` option which will cause validations to be skipped on blank
-data (a blank string) when set to true.
+Validators will skip validations on blank values when the `allowBlank` option is set to
+`true`. The `PresenceValidator` ignores this option for obvious reasons.
+You may override the `shouldSkipValidations` method in you custom
+`Validator` objects to change this behaviour.
 
 # Building Ember-Validations
 

--- a/packages/ember-validations/lib/validator.js
+++ b/packages/ember-validations/lib/validator.js
@@ -3,12 +3,12 @@
 
    This class is used by `Ember.Validations` to validate attributes of an object.
 
-   Subclasses should implement `validate` method, and add an error when the object is not valid.
+   Subclasses should implement the private `_validate` method, and add an error when the object is not valid.
    It could be done with `add` method of `Ember.ValidationErrors` class, as shown in this example:
 
 
        App.TruthyValidator = Ember.Validator.extend({
-         validate: function(obj, attr, value) {
+         _validate: function(obj, attr, value) {
            if (!value) {
              obj.get('validationErrors').add(attr, "should be truthy");
            }

--- a/packages/ember-validations/lib/validator.js
+++ b/packages/ember-validations/lib/validator.js
@@ -49,7 +49,7 @@ Ember.Validator = Ember.Object.extend(/**@scope Ember.Validator.prototype */{
 
 
   /**
-    Method used to determine whether subclass of `Ember.Validator` should call private method `_validate`. Returns false by default so it is not necessary to implement it in sub-classes unless skipping of the validation is required for certain conditions.
+    Method used to determine whether subclass of `Ember.Validator` should call private method `_validate`. Returns true if the allowBlank option is set to true, so it is not necessary to implement it in sub-classes you would like to implement a different logic for the skipping of the validation.
      @param {Object} object
       The object which contains the attribute that has to be validated
      @param {String} attribute
@@ -57,7 +57,11 @@ Ember.Validator = Ember.Object.extend(/**@scope Ember.Validator.prototype */{
      @param {Object} value
       The value of the attribute
   */
-  shouldSkipValidations: function(object, attr, value) {
+  shouldSkipValidations: function(obj, attr, value) {
+    var options = Ember.get(this, 'options');
+    if (options.allowBlank === true) {
+      return value ==="" || value === null || value === undefined;
+    }
     return false;
   },
 

--- a/packages/ember-validations/lib/validator.js
+++ b/packages/ember-validations/lib/validator.js
@@ -31,7 +31,25 @@ Ember.Validator = Ember.Object.extend(/**@scope Ember.Validator.prototype */{
   },
 
   /**
-    Method used to determine whether subclass of `Ember.Validator` should call private method `_validate`.
+    This public method simply calls the `shouldSkipValidations` method and, if it returns true, then calls the private `_validate` function.
+     @param {Object} object
+      The object which contains the attribute that has to be validated
+     @param {String} attribute
+      The attribute path on which the validation should be done
+     @param {Object} value
+      The value of the attribute
+  */
+  validate: function(obj, attr, value) {
+    if (this.shouldSkipValidations(obj, attr, value)) {
+      return false;
+    } else {
+      this._validate(obj, attr, value);
+    }
+  },
+
+
+  /**
+    Method used to determine whether subclass of `Ember.Validator` should call private method `_validate`. Returns false by default so it is not necessary to implement it in sub-classes unless skipping of the validation is required for certain conditions.
      @param {Object} object
       The object which contains the attribute that has to be validated
      @param {String} attribute
@@ -43,7 +61,7 @@ Ember.Validator = Ember.Object.extend(/**@scope Ember.Validator.prototype */{
     return false;
   },
 
-  /**
+  /** @private
      Abstract method used to validate the attribute of an object.
 
      @param {Object} object
@@ -53,7 +71,7 @@ Ember.Validator = Ember.Object.extend(/**@scope Ember.Validator.prototype */{
      @param {Object} value
       The value of the attribute
   */
-  validate: function(obj, attr, value) {
+  _validate: function(obj, attr, value) {
     throw new Error("Ember.Validator subclasses should implement validate() method.");
   },
 

--- a/packages/ember-validations/lib/validator.js
+++ b/packages/ember-validations/lib/validator.js
@@ -31,6 +31,19 @@ Ember.Validator = Ember.Object.extend(/**@scope Ember.Validator.prototype */{
   },
 
   /**
+    Method used to determine whether subclass of `Ember.Validator` should call private method `_validate`.
+     @param {Object} object
+      The object which contains the attribute that has to be validated
+     @param {String} attribute
+      The attribute path on which the validation should be done
+     @param {Object} value
+      The value of the attribute
+  */
+  shouldSkipValidations: function(object, attr, value) {
+    return false;
+  },
+
+  /**
      Abstract method used to validate the attribute of an object.
 
      @param {Object} object

--- a/packages/ember-validations/lib/validators/format.js
+++ b/packages/ember-validations/lib/validators/format.js
@@ -18,7 +18,7 @@ Ember.ValidationError.addMessages({
    @extends Ember.Validator
  */
 Ember.Validators.FormatValidator = Ember.Validator.extend({
-  validate: function(obj, attr, value) {
+  _validate: function(obj, attr, value) {
     var options = get(this, 'options'),
         errors = get(obj, 'validationErrors'),
         optionValue;
@@ -31,6 +31,15 @@ Ember.Validators.FormatValidator = Ember.Validator.extend({
     optionValue = this.optionValue(obj, 'without');
     if ((typeof optionValue === 'string' || optionValue instanceof RegExp) && value.match(optionValue)) {
       errors.add(attr, 'invalid');
+    }
+  },
+
+  shouldSkipValidations: function(obj, attr, value) {
+    var options = get(this, 'options');
+    if (!((options.allowBlank === true) && ((value ==="") || (value === null) || (value === undefined)))) {
+      return false;
+    } else {
+      return true;
     }
   }
 });

--- a/packages/ember-validations/lib/validators/format.js
+++ b/packages/ember-validations/lib/validators/format.js
@@ -32,14 +32,6 @@ Ember.Validators.FormatValidator = Ember.Validator.extend({
     if ((typeof optionValue === 'string' || optionValue instanceof RegExp) && value.match(optionValue)) {
       errors.add(attr, 'invalid');
     }
-  },
-
-  shouldSkipValidations: function(obj, attr, value) {
-    var options = get(this, 'options');
-    if (!((options.allowBlank === true) && ((value ==="") || (value === null) || (value === undefined)))) {
-      return false;
-    } else {
-      return true;
-    }
   }
+
 });

--- a/packages/ember-validations/lib/validators/length.js
+++ b/packages/ember-validations/lib/validators/length.js
@@ -44,14 +44,6 @@ Ember.Validators.LengthValidator = Ember.Validator.extend(/** @scope Ember.Valid
         errors.add(attr, 'tooLongLength', {value: optionValue});
       }
     }
-  },
-
-  shouldSkipValidations: function(obj, attr, value) {
-    var options = get(this, 'options');
-    if (!((options.allowBlank === true) && ((value ==="") || (value === null) || (value === undefined)))) {
-      return false;
-    } else {
-      return true;
-    }
   }
+
 });

--- a/packages/ember-validations/lib/validators/length.js
+++ b/packages/ember-validations/lib/validators/length.js
@@ -21,7 +21,7 @@ Ember.ValidationError.addMessages({
 Ember.Validators.LengthValidator = Ember.Validator.extend(/** @scope Ember.Validators.LengthValidator */{
 
   /** @private */
-  validate: function(obj, attr, value) {
+  _validate: function(obj, attr, value) {
     var options = get(this, 'options'),
         errors = get(obj, 'validationErrors'),
         length = value ? Ember.get(value, 'length') : 0,
@@ -43,6 +43,15 @@ Ember.Validators.LengthValidator = Ember.Validator.extend(/** @scope Ember.Valid
       if (optionValue !== null && length > optionValue) {
         errors.add(attr, 'tooLongLength', {value: optionValue});
       }
+    }
+  },
+
+  shouldSkipValidations: function(obj, attr, value) {
+    var options = get(this, 'options');
+    if (!((options.allowBlank === true) && ((value ==="") || (value === null) || (value === undefined)))) {
+      return false;
+    } else {
+      return true;
     }
   }
 });

--- a/packages/ember-validations/lib/validators/numericality.js
+++ b/packages/ember-validations/lib/validators/numericality.js
@@ -56,42 +56,39 @@ Ember.Validators.NumericalityValidator = Ember.Validator.extend(/** @scope Ember
         parsedInt = parseInt(value, 10),
         errors = get(obj, 'validationErrors');
 
-    var options = get(this, 'options');
-    if (!((options.allowBlank === true) && ((value ==="") || (value === null) || (value === undefined)))) {
+    if (isNaN(value) || isNaN(parsedValue)) {
+      errors.add(attr, 'notNumber');
+    } else {
+      var options = get(this, 'options');
+      if (options.onlyInteger === true && (parsedValue !== parsedInt)) {
+        errors.add(attr, 'notInteger');
+      }
 
-      if (isNaN(value) || isNaN(parsedValue)) {
-        errors.add(attr, 'notNumber');
-      } else {
-        if (options.onlyInteger === true && (parsedValue !== parsedInt)) {
-          errors.add(attr, 'notInteger');
-        }
+      var optionValue;
 
-        var optionValue;
+      optionValue = this.optionValue(obj, 'greaterThan', 'number');
+      if (optionValue !== null && parsedValue <= optionValue) {
+        errors.add(attr, 'notGreaterThan', {value: optionValue});
+      }
 
-        optionValue = this.optionValue(obj, 'greaterThan', 'number');
-        if (optionValue !== null && parsedValue <= optionValue) {
-          errors.add(attr, 'notGreaterThan', {value: optionValue});
-        }
+      optionValue = this.optionValue(obj, 'greaterThanOrEqualTo', 'number');
+      if (optionValue !== null && parsedValue < optionValue) {
+        errors.add(attr, 'notGreaterThanOrEqualTo', {value: optionValue});
+      }
 
-        optionValue = this.optionValue(obj, 'greaterThanOrEqualTo', 'number');
-        if (optionValue !== null && parsedValue < optionValue) {
-          errors.add(attr, 'notGreaterThanOrEqualTo', {value: optionValue});
-        }
+      optionValue = this.optionValue(obj, 'lessThan', 'number');
+      if (optionValue !== null && parsedValue >= optionValue) {
+        errors.add(attr, 'notLessThan', {value: optionValue});
+      }
 
-        optionValue = this.optionValue(obj, 'lessThan', 'number');
-        if (optionValue !== null && parsedValue >= optionValue) {
-          errors.add(attr, 'notLessThan', {value: optionValue});
-        }
+      optionValue = this.optionValue(obj, 'lessThanOrEqualTo', 'number');
+      if (optionValue !== null && parsedValue > optionValue) {
+        errors.add(attr, 'notLessThanOrEqualTo', {value: optionValue});
+      }
 
-        optionValue = this.optionValue(obj, 'lessThanOrEqualTo', 'number');
-        if (optionValue !== null && parsedValue > optionValue) {
-          errors.add(attr, 'notLessThanOrEqualTo', {value: optionValue});
-        }
-
-        optionValue = this.optionValue(obj, 'equalTo', 'number');
-        if (optionValue !== null && parsedValue !== optionValue) {
-          errors.add(attr, 'notEqual', {value: optionValue});
-        }
+      optionValue = this.optionValue(obj, 'equalTo', 'number');
+      if (optionValue !== null && parsedValue !== optionValue) {
+        errors.add(attr, 'notEqual', {value: optionValue});
       }
     }
   },
@@ -99,14 +96,6 @@ Ember.Validators.NumericalityValidator = Ember.Validator.extend(/** @scope Ember
   isValidForOption: function(obj, option, condition) {
     var optionValue = this.optionValue(option);
     return optionValue !== null && condition.apply(obj, optionValue);
-  },
-
-  shouldSkipValidations: function(obj, attr, value) {
-    var options = get(this, 'options');
-    if (!((options.allowBlank === true) && ((value ==="") || (value === null) || (value === undefined)))) {
-      return false;
-    } else {
-      return true;
-    }
   }
+
 });

--- a/packages/ember-validations/lib/validators/numericality.js
+++ b/packages/ember-validations/lib/validators/numericality.js
@@ -56,39 +56,42 @@ Ember.Validators.NumericalityValidator = Ember.Validator.extend(/** @scope Ember
         parsedInt = parseInt(value, 10),
         errors = get(obj, 'validationErrors');
 
-    if (isNaN(value) || isNaN(parsedValue)) {
-      errors.add(attr, 'notNumber');
-    } else {
-      var options = get(this, 'options');
-      if (options.onlyInteger === true && (parsedValue !== parsedInt)) {
-        errors.add(attr, 'notInteger');
-      }
+    var options = get(this, 'options');
+    if (!((options.allowBlank === true) && ((value ==="") || (value === null) || (value === undefined)))) {
 
-      var optionValue;
+      if (isNaN(value) || isNaN(parsedValue)) {
+        errors.add(attr, 'notNumber');
+      } else {
+        if (options.onlyInteger === true && (parsedValue !== parsedInt)) {
+          errors.add(attr, 'notInteger');
+        }
 
-      optionValue = this.optionValue(obj, 'greaterThan', 'number');
-      if (optionValue !== null && parsedValue <= optionValue) {
-        errors.add(attr, 'notGreaterThan', {value: optionValue});
-      }
+        var optionValue;
 
-      optionValue = this.optionValue(obj, 'greaterThanOrEqualTo', 'number');
-      if (optionValue !== null && parsedValue < optionValue) {
-        errors.add(attr, 'notGreaterThanOrEqualTo', {value: optionValue});
-      }
+        optionValue = this.optionValue(obj, 'greaterThan', 'number');
+        if (optionValue !== null && parsedValue <= optionValue) {
+          errors.add(attr, 'notGreaterThan', {value: optionValue});
+        }
 
-      optionValue = this.optionValue(obj, 'lessThan', 'number');
-      if (optionValue !== null && parsedValue >= optionValue) {
-        errors.add(attr, 'notLessThan', {value: optionValue});
-      }
+        optionValue = this.optionValue(obj, 'greaterThanOrEqualTo', 'number');
+        if (optionValue !== null && parsedValue < optionValue) {
+          errors.add(attr, 'notGreaterThanOrEqualTo', {value: optionValue});
+        }
 
-      optionValue = this.optionValue(obj, 'lessThanOrEqualTo', 'number');
-      if (optionValue !== null && parsedValue > optionValue) {
-        errors.add(attr, 'notLessThanOrEqualTo', {value: optionValue});
-      }
+        optionValue = this.optionValue(obj, 'lessThan', 'number');
+        if (optionValue !== null && parsedValue >= optionValue) {
+          errors.add(attr, 'notLessThan', {value: optionValue});
+        }
 
-      optionValue = this.optionValue(obj, 'equalTo', 'number');
-      if (optionValue !== null && parsedValue !== optionValue) {
-        errors.add(attr, 'notEqual', {value: optionValue});
+        optionValue = this.optionValue(obj, 'lessThanOrEqualTo', 'number');
+        if (optionValue !== null && parsedValue > optionValue) {
+          errors.add(attr, 'notLessThanOrEqualTo', {value: optionValue});
+        }
+
+        optionValue = this.optionValue(obj, 'equalTo', 'number');
+        if (optionValue !== null && parsedValue !== optionValue) {
+          errors.add(attr, 'notEqual', {value: optionValue});
+        }
       }
     }
   },

--- a/packages/ember-validations/lib/validators/numericality.js
+++ b/packages/ember-validations/lib/validators/numericality.js
@@ -50,14 +50,6 @@ Ember.ValidationError.addMessages({
  */
 Ember.Validators.NumericalityValidator = Ember.Validator.extend(/** @scope Ember.Validators.NumericalityValidator.prototype */{
 
-  validate: function(obj, attr, value) {
-    if (this.shouldSkipValidations(obj, attr, value)) {
-      return false;
-    } else {
-      this._validate(obj, attr, value);
-    }
-  },
-
   /** @private */
   _validate: function(obj, attr, value) {
     var parsedValue = parseFloat(value),

--- a/packages/ember-validations/lib/validators/numericality.js
+++ b/packages/ember-validations/lib/validators/numericality.js
@@ -50,8 +50,16 @@ Ember.ValidationError.addMessages({
  */
 Ember.Validators.NumericalityValidator = Ember.Validator.extend(/** @scope Ember.Validators.NumericalityValidator.prototype */{
 
-  /** @private */
   validate: function(obj, attr, value) {
+    if (this.shouldSkipValidations(obj, attr, value)) {
+      return false;
+    } else {
+      this._validate(obj, attr, value);
+    }
+  },
+
+  /** @private */
+  _validate: function(obj, attr, value) {
     var parsedValue = parseFloat(value),
         parsedInt = parseInt(value, 10),
         errors = get(obj, 'validationErrors');
@@ -99,5 +107,14 @@ Ember.Validators.NumericalityValidator = Ember.Validator.extend(/** @scope Ember
   isValidForOption: function(obj, option, condition) {
     var optionValue = this.optionValue(option);
     return optionValue !== null && condition.apply(obj, optionValue);
+  },
+
+  shouldSkipValidations: function(obj, attr, value) {
+    var options = get(this, 'options');
+    if (!((options.allowBlank === true) && ((value ==="") || (value === null) || (value === undefined)))) {
+      return false;
+    } else {
+      return true;
+    }
   }
 });

--- a/packages/ember-validations/lib/validators/presence.js
+++ b/packages/ember-validations/lib/validators/presence.js
@@ -11,7 +11,7 @@ Ember.ValidationError.addMessage('blank', "can't be blank");
    @extends Ember.Validator
 */
 Ember.Validators.PresenceValidator = Ember.Validator.extend({
-  validate: function(obj, attr, value) {
+  _validate: function(obj, attr, value) {
     var invalidValues = Ember.A([undefined, null]);
     if (invalidValues.contains(value) || (value.match && value.match(/^\s*$/))) {
       obj.get('validationErrors').add(attr, "blank");

--- a/packages/ember-validations/lib/validators/presence.js
+++ b/packages/ember-validations/lib/validators/presence.js
@@ -11,6 +11,19 @@ Ember.ValidationError.addMessage('blank', "can't be blank");
    @extends Ember.Validator
 */
 Ember.Validators.PresenceValidator = Ember.Validator.extend({
+  /**
+    The presence validators `shouldSkipValidations` method should return false regardless of whether the `allowBlank` option is set to `true` since it would be contradictory for a PresenceValidator to allow blank values.
+     @param {Object} object
+      The object which contains the attribute that has to be validated
+     @param {String} attribute
+      The attribute path on which the validation should be done
+     @param {Object} value
+      The value of the attribute
+  */
+  shouldSkipValidations: function(obj, attr, value) {
+    return false;
+  },
+
   _validate: function(obj, attr, value) {
     var invalidValues = Ember.A([undefined, null]);
     if (invalidValues.contains(value) || (value.match && value.match(/^\s*$/))) {

--- a/packages/ember-validations/tests/validators/format_test.js
+++ b/packages/ember-validations/tests/validators/format_test.js
@@ -33,3 +33,7 @@ testBothValidities(
   "bdef",
   "abcdef", {invalid: "is invalid"}
 );
+
+testNoError(
+  "allowBlank option", vClass, {allowBlank:true, 'with': "abc"}, ""
+);

--- a/packages/ember-validations/tests/validators/length_test.js
+++ b/packages/ember-validations/tests/validators/length_test.js
@@ -27,3 +27,7 @@ testBothValidities(
   "123",
   "12", {wrongLength: "is the wrong length (should be 3 characters)"}
 );
+
+testNoError(
+  "allowBlank option", vClass, {allowBlank: true, minimum: 3}, ""
+);

--- a/packages/ember-validations/tests/validators/numericality_test.js
+++ b/packages/ember-validations/tests/validators/numericality_test.js
@@ -51,3 +51,7 @@ testBothValidities(
   "12",
   "11", {notEqual: "is not equal to 12"}
 );
+
+testNoError(
+  "allowBlank option", vClass, {allowBlank: true}, ""
+);

--- a/packages/ember-validations/tests/validators/presence_test.js
+++ b/packages/ember-validations/tests/validators/presence_test.js
@@ -37,3 +37,22 @@ test("should not add error when the attribute is present", function() {
   validator.validate(model, 'name', 0);
   equal(get(model, 'validationErrors.name.keys'), undefined, "should not set 'name' error for value 0");
 });
+
+test("should add error when attribute is present, even if allowBlank option is set to true", function() {
+  var invalidValues = [undefined, null, '', ' ', '  '];
+  invalidValues.forEach(function(val, index) {
+    set(model, 'validationErrors', Ember.ValidationErrors.create());
+    set(validator, 'options', {allowBlank: true});
+    validator.validate(model, 'name', val);
+
+    var errors = get(model, 'validationErrors.name');
+    ok(errors, "has a errors.name object");
+
+    var errorKeys = get(errors, 'keys');
+    equal(errorKeys.length, 1, "has one error");
+    equal(errorKeys[0], 'blank', "has right key");
+
+    var errorMessage = get(errors, 'messages');
+    equal(errorMessage[0], "can't be blank", "has right message");
+  });
+});


### PR DESCRIPTION
I don't intend this as a real pull request but I would like to get your feedback early on how best to implement this feature. 

On the implementation: I've add a simple conditional on the `validate` method of `Ember.Validators.NumericalityValidator`. I'm not sure if this a too ugly way to do it? If I continue this way I would add this conditional to validate method of the other validators. Perhaps another way would be to implement this somehow in the parent `Ember.Validator` class. But this would meed the classes that extend `Ember.Validator` would need to all call `_super()` and then perhaps you lose the error handling to ensure they all have a `validate` function. Also, it doesn't make sense for the presence validator. Of course I'll modify the documentation for the real pull request.

On the test: It's the simplest test, just to ensure blank strings are allow through. But it passes and none of the other tests are failing as a result.

If you have a moment, please let me know your thoughts on the best approach and I'll go back and revise.

Thanks,
Sean
