### PR TITLE
Fix to ember-validations to accept 'content' property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+rvm:
+  - 1.9.3
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+script: "rake test"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Ember Validations
+# Ember Validations [![Build Status](https://secure.travis-ci.org/lcoq/ember-validations.png?branch=master)](http://travis-ci.org/lcoq/ember-validations)
 
 Ember-validations is a Ember.js library that can handle object validations. If you have to check the validity of object properties, 
 this library does it for you. You just have to declare which property you want to validate, and which kind of validation you want for this property.

--- a/packages/ember-validations/lib/errors.js
+++ b/packages/ember-validations/lib/errors.js
@@ -8,8 +8,8 @@ var get = Ember.get, set = Ember.set;
 
  */
 Ember.ValidationErrors = Ember.Object.extend(/** @scope Ember.ValidationErrors.prototype */{
-  nestedErrors: null,
-  content: null,
+  _nestedErrors: null,
+  _content: null,
 
   /** @private */
   init: function() {
@@ -81,7 +81,7 @@ Ember.ValidationErrors = Ember.Object.extend(/** @scope Ember.ValidationErrors.p
     @property
   */
   keys: Ember.computed(function() {
-    var content = get(this, 'content'), keys = Ember.A();
+    var content = get(this, '_content'), keys = Ember.A();
     content.forEach(function(error) { keys.push(error.get('key')); });
     return keys;
   }).property('length').cacheable(),
@@ -96,7 +96,7 @@ Ember.ValidationErrors = Ember.Object.extend(/** @scope Ember.ValidationErrors.p
     @property
    */
   messages: Ember.computed(function() {
-    var content = get(this, 'content'), messages = Ember.A();
+    var content = get(this, '_content'), messages = Ember.A();
     content.forEach(function(error) { messages.push(error.get('message')); });
     return messages;
   }).property('length').cacheable(),
@@ -108,8 +108,8 @@ Ember.ValidationErrors = Ember.Object.extend(/** @scope Ember.ValidationErrors.p
    */
   length: Ember.computed(function() {
     var length = 0,
-        content = get(this, 'content'),
-        errors = get(this, 'nestedErrors');
+        content = get(this, '_content'),
+        errors = get(this, '_nestedErrors');
 
     length += content.length;
     errors.forEach(function(nestedErrorsPath, nestedErrors) { length += get(nestedErrors, 'length'); });
@@ -118,7 +118,7 @@ Ember.ValidationErrors = Ember.Object.extend(/** @scope Ember.ValidationErrors.p
 
   /** @private */
   unknownProperty: function(key) {
-    var errors = get(this, 'nestedErrors');
+    var errors = get(this, '_nestedErrors');
     return errors.get(key);
   },
 
@@ -144,7 +144,7 @@ Ember.ValidationErrors = Ember.Object.extend(/** @scope Ember.ValidationErrors.p
         customMessage: customMessage,
         messageFormat: format
       });
-      get(this, 'content').pushObject(error);
+      get(this, '_content').pushObject(error);
 
     } else {
       var attrPaths = this._pathsForAttribute(attributePath);
@@ -169,7 +169,7 @@ Ember.ValidationErrors = Ember.Object.extend(/** @scope Ember.ValidationErrors.p
     if (!attributePath) {
       this._resetErrors();
     } else {
-      var nestedErrors = get(this, 'nestedErrors'),
+      var nestedErrors = get(this, '_nestedErrors'),
           attrPaths = this._pathsForAttribute(attributePath);
       var errors = nestedErrors.get(attrPaths['path']);
       if (errors) {
@@ -190,7 +190,7 @@ Ember.ValidationErrors = Ember.Object.extend(/** @scope Ember.ValidationErrors.p
 
   /** @private */
   _getOrCreateNestedErrors: function(path) {
-    var nestedErrors = get(this, 'nestedErrors');
+    var nestedErrors = get(this, '_nestedErrors');
     var errors = nestedErrors.get(path);
     if (!errors) {
       errors = Ember.ValidationErrors.create();
@@ -210,8 +210,8 @@ Ember.ValidationErrors = Ember.Object.extend(/** @scope Ember.ValidationErrors.p
 
   /** @private */
   _resetErrors: function() {
-    set(this, 'content', Ember.A());
-    set(this, 'nestedErrors', Ember.Map.create());
+    set(this, '_content', Ember.A());
+    set(this, '_nestedErrors', Ember.Map.create());
   },
 
 
@@ -221,7 +221,7 @@ Ember.ValidationErrors = Ember.Object.extend(/** @scope Ember.ValidationErrors.p
         data = Ember.A();
     directData.forEach(function(singleData) { data.push(['', singleData]); });
 
-    var nestedErrors = get(this, 'nestedErrors');
+    var nestedErrors = get(this, '_nestedErrors');
     nestedErrors.forEach(function(path, errors) {
       var allErrorsDataPath = 'all' + dataName[0].toUpperCase() + dataName.slice(1);
       var allErrorsData = errors.get(allErrorsDataPath);

--- a/packages/ember-validations/tests/errors_test.js
+++ b/packages/ember-validations/tests/errors_test.js
@@ -136,3 +136,9 @@ test("get fullMessages should return formatted messages", function() {
   errors.add('address.city', 'lengthTooLong', {length: 20});
   deepEqual(get(errors, 'fullMessages'), expected, "has 'lengthTooLong' message");
 });
+
+test("can get nested errors inside a 'content' property", function() {
+  var expected = ['content.title can not be blank'];
+  errors.add('content.title', 'cantBeBlank');
+  deepEqual(get(errors, 'fullMessages'), expected, "has 'cantBeBlank' message");
+});


### PR DESCRIPTION
Hi Louis!

Thanks for writing this library! I've found it useful and incorporated it into my projects.

I made one small fix, where the current implementation doesn't like to nest errors inside any property that is also named 'content' -- this property conflicts with the ValidationError class's 'content' property. So I renamed the ValidationError's properties from 'content' and 'nestedErrors' to '_content' and '_nestedErrors'. And added a test.

Hope this helps!

-Gabe
