### PR TITLE
Fixing README Custom Validations example

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,11 @@ You can define custom validation function, like this:
 
 ```js
 password: {
-  myCustomValidator: function(object, attribute, value) {
-    if (!value.match(/[A-Z]/)) {
-      object.get('validationErrors').add(attribute, 'invalid');
+  myCustomValidator: {
+    validator: function(object, attribute, value) {
+      if (!value.match(/[A-Z]/)) {
+        object.get('validationErrors').add(attribute, 'invalid');
+      }
     }
   }
 }


### PR DESCRIPTION
Hi there,

I started using ember-validations with records from a fork of ember-data I'm working with and I'm using TDD to learn exactly how your library works.

When I tried to define a custom validator as shown in the current README, I was a little baffled to find my test case assumptions were erring out.

Going with the README example, I first tried this simple test validator:

``` javascript
App.Test = DS.Model.extend(Ember.Validations, {
  validations: {
    stuff: {
      inSet: function (object, attribute, value) {
        var set = { foo: 1, bar: 1, fizz: 1 };

        if (!set[value]) {
          object.get('validationErrors').add(attribute, 'is not in the set');
        }
      }
    }
  }
});
```

calling `validate` on a record created from this Test class, my test case produced this error: `Uncaught Error: Validator not found for name 'inSet'.` I then looked at the `getValidator` function and noticed that the logic only works if you place the function in a key `validator` on an object that is the value of your custom validator key:

``` javascript
App.Test = DS.Model.extend(Ember.Validations, {
  validations: {
    stuff: {
      inSet: {
        validator: function (object, attribute, value) {
          var set = { foo: 1, bar: 1, fizz: 1 };

          if (!set[value]) {
            object.get('validationErrors').add(attribute, 'is not in the set');
          }
        }
      }
    }
  }
});
```

Since it seems to work just fine, I figured it probably wasn't a bug, but rather just an incorrect example in the README, so I figured I'd put in a pull request to fix the README so that anyone else doesn't get tripped up by it like I did.

Otherwise the lib seems to be working great. Nice work and thanks :)
