### PR TITLE
Fix README.md match example

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,7 @@ Example:
 ```js
 password: {
   match: {
-    property: {
-      "confirmPassword"
-    }
+    property: "confirmPassword"
   }
 },
 confirmPassword: {


### PR DESCRIPTION
Otherwise it gets `Uncaught SyntaxError: Unexpected token }`
